### PR TITLE
2 fixes for menu context code for windows

### DIFF
--- a/windows/LiferayNativityShellExtensions/LiferayNativityContextMenus/LiferayNativityContextMenus.cpp
+++ b/windows/LiferayNativityShellExtensions/LiferayNativityContextMenus/LiferayNativityContextMenus.cpp
@@ -285,7 +285,10 @@ int LiferayNativityContextMenus::_AddMenu(HMENU hMenu, ContextMenuItem* menu, in
 	}
 	else if (text->compare(SEPARATOR) == 0)
 	{
-		_InsertSeparator(hMenu, location);
+		if(_InsertSeparator(hMenu, location))
+		{
+			cmdCount++;
+		}
 	}
 	else
 	{


### PR DESCRIPTION
I have fixed 2 bugs in code for context menu on Windows:
1. Menu entries always appeared as last, even after the "Properties" entry + when the entries were shown, an "Open" entry dissapeared.
The bug was caused by usage of incorrect variable as the position to insert entries to. The code used idFirstCmd, while the position is stored in indexMenu variable according to the documentation:
http://msdn.microsoft.com/en-us/library/windows/desktop/bb776097%28v=vs.85%29.aspx and sample (the last one): http://msdn.microsoft.com/en-us/library/windows/desktop/hh127443%28v=vs.85%29.aspx
2. The entries in a submenu appeared in reverse order on Windows due to incorrect scope of subLocation variable.

The fixes were tested on both Windows 8.1 64-bit and Windows 7 64-bit.
