### PR TITLE
Fixed encoding of load.applescript

### DIFF
--- a/java/src/resources/osax/load.applescript
+++ b/java/src/resources/osax/load.applescript
@@ -1,5 +1,5 @@
 tell application "Finder"
-	try
-		«event NVTYload»
-	end try
+    try
+        «event NVTYload»
+    end try
 end tell


### PR DESCRIPTION
Script was not loaded via Java code due to bad encoding. Changed to UTF-8.