### PR TITLE
Only first menu item without subitems shown on Windows

### DIFF
--- a/windows/LiferayNativityShellExtensions/LiferayNativityContextMenus/ContextMenuUtil.cpp
+++ b/windows/LiferayNativityShellExtensions/LiferayNativityContextMenus/ContextMenuUtil.cpp
@@ -140,6 +140,7 @@ bool ContextMenuUtil::InitMenus(void)
 			Json::Value jsonContextMenuItem = jsonContextMenuItemsList[i];
 
 			ContextMenuItem* contextMenuItem = new ContextMenuItem();
+			contextMenuItem->SetId(i);
 
 			if (!_ParseContextMenuItem(jsonContextMenuItem, contextMenuItem))
 			{


### PR DESCRIPTION
**Problem**:  On Windows, when you add 2 or more context menu items **without** subitems, only the first one will be shown.

**Cause**: The problem is due to *Id* of menu item being never assigned in any code path in windows code.

I am not sure whether it is the correct place to initialize it or whether the Id is really meant to be an index of entry in the vector (what is *Index* field then?) as there is no documentation, but the fix seems to work. After the change every menu entry is shown instead of just the first one.