### PR TITLE
Updated uninstall method to use TColumnCell for 10.10 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build.*.properties
 xcuserdata/
 dist
 tmp
+.settings/
 
 java/bin
 java/classes
@@ -29,5 +30,4 @@ windows/LiferayNativityShellExtensions/LiferayNativityWindowsUtil/com_liferay_na
 windows/LiferayNativityShellExtensions/NativityTest/Debug
 windows/LiferayNativityShellExtensions/NativityTest/Release
 
-mac/LiferayNativity.xcworkspace/xcshareddata
 mac/LiferayNativityFinder/MethodNames.h

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ windows/LiferayNativityShellExtensions/LiferayNativityWindowsUtil/Release
 windows/LiferayNativityShellExtensions/LiferayNativityWindowsUtil/com_liferay_nativity*
 windows/LiferayNativityShellExtensions/NativityTest/Debug
 windows/LiferayNativityShellExtensions/NativityTest/Release
+
+mac/LiferayNativity.xcworkspace/xcshareddata
+mac/LiferayNativityFinder/MethodNames.h

--- a/mac/LiferayNativityFinder/FinderHook.m
+++ b/mac/LiferayNativityFinder/FinderHook.m
@@ -141,7 +141,7 @@ static BOOL installed = NO;
 
 	[self hookMethod:@selector(IconOverlayHandlers_IKFinderReflectiveIconCell_drawImage:) inClass:@"IKFinderReflectiveIconCell" toCallToTheNewMethod:@selector(drawImage:)];     // 10.7 & 10.8 & 10.9 (Icon View arrange by everything else)
 
-	[self hookMethod:@selector(IconOverlayHandlers_drawIconWithFrame:) inClass:@"TListViewIconAndTextCell" toCallToTheNewMethod:@selector(drawIconWithFrame:)];     // 10.7 & 10.8 & 10.9 Column View
+	[self hookMethod:@selector(IconOverlayHandlers_drawIconWithFrame:) inClass:@"TColumnCell" toCallToTheNewMethod:@selector(drawIconWithFrame:)];     // 10.7 & 10.8 & 10.9 & 10.10 Column View
 
 	[self hookMethod:@selector(IconOverlayHandlers_drawRect:) inClass:@"TDimmableIconImageView" toCallToTheNewMethod:@selector(drawRect:)];     // 10.9 (List and Coverflow Views)
 

--- a/mac/LiferayNativityFinder/FinderHook.m
+++ b/mac/LiferayNativityFinder/FinderHook.m
@@ -89,13 +89,11 @@ static BOOL installed = NO;
 	[RequestManager sharedInstance];
 
 	// Icons
-	[self hookMethod:@selector(drawImage:) inClass:@"IKImageBrowserCell" toCallToTheNewMethod:@selector(IconOverlayHandlers_IKImageBrowserCell_drawImage:)];     // 10.7 & 10.8 & 10.9 (Icon View arrange by name)
+	[self hookMethod:@selector(layerForType:) inClass:@"IKImageBrowserCell" toCallToTheNewMethod:@selector(IconOverlayHandlers_IKImageBrowserCell_layerForType:)];     // 10.7 & 10.8 & 10.9 & 10.10 (Icon View)
 
-	[self hookMethod:@selector(drawImage:) inClass:@"IKFinderReflectiveIconCell" toCallToTheNewMethod:@selector(IconOverlayHandlers_IKFinderReflectiveIconCell_drawImage:)];     // 10.7 & 10.8 & 10.9 (Icon View arrange by everything else)
+	[self hookMethod:@selector(drawIconWithFrame:) inClass:@"TColumnCell" toCallToTheNewMethod:@selector(IconOverlayHandlers_TColumnCell_drawIconWithFrame:)];     // 10.7 & 10.8 & 10.9 & 10.10 (Column View)
 
-	[self hookMethod:@selector(drawIconWithFrame:) inClass:@"TColumnCell" toCallToTheNewMethod:@selector(IconOverlayHandlers_drawIconWithFrame:)];     // 10.7 & 10.8 & 10.9 & 10.10 Column View
-
-	[self hookMethod:@selector(drawRect:) inClass:@"TDimmableIconImageView" toCallToTheNewMethod:@selector(IconOverlayHandlers_drawRect:)];     // 10.9 (List and Coverflow Views)
+	[self hookMethod:@selector(drawRect:) inClass:@"TDimmableIconImageView" toCallToTheNewMethod:@selector(IconOverlayHandlers_TDimmableIconImageView_drawRect:)];     // 10.9 & 10.10 (List and Coverflow Views)
 
 	// Context Menus
 	[self hookClassMethod:@selector(addViewSpecificStuffToMenu:browserViewController:context:) inClass:@"TContextMenu" toCallToTheNewMethod:@selector(ContextMenuHandlers_addViewSpecificStuffToMenu:browserViewController:context:)];     // 10.7 & 10.8
@@ -137,13 +135,11 @@ static BOOL installed = NO;
 	[[RequestManager sharedInstance] dealloc];
 
 	// Icons
-	[self hookMethod:@selector(IconOverlayHandlers_IKImageBrowserCell_drawImage:) inClass:@"IKImageBrowserCell" toCallToTheNewMethod:@selector(drawImage:)];     // 10.7 & 10.8 & 10.9 (Icon View arrange by name)
+	[self hookMethod:@selector(IconOverlayHandlers_IKImageBrowserCell_layerForType:) inClass:@"IKImageBrowserCell" toCallToTheNewMethod:@selector(layerForType:)];     // 10.7 & 10.8 & 10.9 & 10.10 (Icon View)
 
-	[self hookMethod:@selector(IconOverlayHandlers_IKFinderReflectiveIconCell_drawImage:) inClass:@"IKFinderReflectiveIconCell" toCallToTheNewMethod:@selector(drawImage:)];     // 10.7 & 10.8 & 10.9 (Icon View arrange by everything else)
+	[self hookMethod:@selector(IconOverlayHandlers_TColumnCell_drawIconWithFrame:) inClass:@"TColumnCell" toCallToTheNewMethod:@selector(drawIconWithFrame:)];     // 10.7 & 10.8 & 10.9 & 10.10 (Column View)
 
-	[self hookMethod:@selector(IconOverlayHandlers_drawIconWithFrame:) inClass:@"TColumnCell" toCallToTheNewMethod:@selector(drawIconWithFrame:)];     // 10.7 & 10.8 & 10.9 & 10.10 Column View
-
-	[self hookMethod:@selector(IconOverlayHandlers_drawRect:) inClass:@"TDimmableIconImageView" toCallToTheNewMethod:@selector(drawRect:)];     // 10.9 (List and Coverflow Views)
+	[self hookMethod:@selector(IconOverlayHandlers_TDimmableIconImageView_drawRect:) inClass:@"TDimmableIconImageView" toCallToTheNewMethod:@selector(drawRect:)];     // 10.9 & 10.10 (List and Coverflow Views)
 
 	// Context Menus
 	[self hookClassMethod:@selector(ContextMenuHandlers_addViewSpecificStuffToMenu:browserViewController:context:) inClass:@"TContextMenu" toCallToTheNewMethod:@selector(addViewSpecificStuffToMenu:browserViewController:context:)];     // 10.7 & 10.8

--- a/mac/LiferayNativityFinder/IconOverlayHandlers.h
+++ b/mac/LiferayNativityFinder/IconOverlayHandlers.h
@@ -51,9 +51,7 @@
 
 @interface NSObject (IconOverlayHandlers)
 
-- (void)IconOverlayHandlers_drawIconWithFrame:(struct CGRect)arg1;
-- (void)IconOverlayHandlers_drawRect:(struct CGRect)arg1;
-- (void)IconOverlayHandlers_IKFinderReflectiveIconCell_drawImage:(id)arg1;
-- (void)IconOverlayHandlers_IKImageBrowserCell_drawImage:(id)arg1;
+- (void)IconOverlayHandlers_TColumnCell_drawIconWithFrame:(struct CGRect)arg1;
+- (void)IconOverlayHandlers_TDimmableIconImageView_drawRect:(struct CGRect)arg1;
 
 @end

--- a/mac/LiferayNativityFinder/IconOverlayHandlers.m
+++ b/mac/LiferayNativityFinder/IconOverlayHandlers.m
@@ -54,12 +54,75 @@
 // someone "borrows" this plugin, randomizing names prevents runtime conflicts
 #include "MethodNames.h"
 
+
+@implementation IKImageBrowserCell (IconOverlayHandlers)
+
+// 10.9 & 10.10 (List View)
+- (CALayer*) IconOverlayHandlers_IKImageBrowserCell_layerForType:(NSString *)type
+{
+	CALayer *layer = [self IconOverlayHandlers_IKImageBrowserCell_layerForType:type];
+
+	if (![type isEqualToString:IKImageBrowserCellForegroundLayer])
+	{
+		return layer;
+	}
+
+	id representedItem = [self representedItem];
+	NSURL *representedItemURL;
+
+	if ([representedItem respondsToSelector:@selector(previewItemURL)])
+	{
+		representedItemURL = [representedItem previewItemURL];
+	}
+	else
+	{
+		return layer;
+	}
+
+	for (NSNumber* imageIndex in [[RequestManager sharedInstance] iconIdForFile:[representedItemURL path]])
+	{
+		if ([imageIndex intValue] > 0)
+		{
+			NSImage *overlayIcon = [[IconCache sharedInstance] getIcon:[NSNumber numberWithInt:[imageIndex intValue]]];
+
+			if (overlayIcon != nil)
+			{
+				NSRect frame = [self frame];
+				NSRect imageFrame = [self imageFrame];
+
+				[overlayIcon setSize:imageFrame.size];
+				[overlayIcon setFlipped:NO];
+
+				CALayer *overlayIconLayer = [CALayer layer];
+				[overlayIconLayer setContents:(id)[overlayIcon CGImageForProposedRect:nil
+																			  context:nil
+																				hints:nil]];
+				[overlayIconLayer setAnchorPoint:NSZeroPoint];
+				[overlayIconLayer setBounds:NSMakeRect(0, 0, imageFrame.size.width, imageFrame.size.height)];
+				[overlayIconLayer setPosition:NSMakePoint(imageFrame.origin.x - frame.origin.x, imageFrame.origin.y - frame.origin.y)];
+
+				if (layer == nil)
+				{
+					layer = [CALayer layer];
+				}
+
+				[layer addSublayer:overlayIconLayer];
+			}
+		}
+	}
+
+	return layer;
+}
+
+@end
+
+
 @implementation NSObject (IconOverlayHandlers)
 
-// 10.7 & 10.8 & 10.9 Column View
-- (void)IconOverlayHandlers_drawIconWithFrame:(struct CGRect)arg1
+// 10.7 & 10.8 & 10.9 & 10.10 (Column View)
+- (void)IconOverlayHandlers_TColumnCell_drawIconWithFrame:(struct CGRect)arg1
 {
-	[self IconOverlayHandlers_drawIconWithFrame:arg1];
+	[self IconOverlayHandlers_TColumnCell_drawIconWithFrame:arg1];
 
 	NSURL* url = [[NSClassFromString(@"FINode") nodeFromNodeRef:[(TIconAndTextCell*)self node]->fNodeRef] previewItemURL];
 
@@ -81,64 +144,10 @@
 	}
 }
 
-- (void)IconOverlayHandlers_IKImageBrowserCell_drawImage:(id)arg1
+// 10.9 & 10.10 (List and Coverflow Views)
+- (void)IconOverlayHandlers_TDimmableIconImageView_drawRect:(struct CGRect)arg1
 {
-	IKImageWrapper* imageWrapper = [self IconOverlayHandlers_imageWrapper:arg1];
-
-	[self IconOverlayHandlers_IKImageBrowserCell_drawImage:imageWrapper];
-}
-
-- (void)IconOverlayHandlers_IKFinderReflectiveIconCell_drawImage:(id)arg1
-{
-	IKImageWrapper* imageWrapper = [self IconOverlayHandlers_imageWrapper:arg1];
-
-	[self IconOverlayHandlers_IKFinderReflectiveIconCell_drawImage:imageWrapper];
-}
-
-- (IKImageWrapper*)IconOverlayHandlers_imageWrapper:(id)arg1
-{
-	TIconViewCell* realSelf = (TIconViewCell*)self;
-	FINode* node = (FINode*)[realSelf representedItem];
-
-	NSURL* url = [node previewItemURL];
-
-	for (NSNumber* imageIndex in [[RequestManager sharedInstance] iconIdForFile:[url path]])
-	{
-		if ([imageIndex intValue] > 0)
-		{
-			NSImage* icon = [arg1 _nsImage];
-
-			[icon lockFocus];
-
-			CGContextRef myContext = [[NSGraphicsContext currentContext] graphicsPort];
-
-			NSImage* iconImage = [[IconCache sharedInstance] getIcon:[NSNumber numberWithInt:[imageIndex intValue]]];
-
-			if (iconImage)
-			{
-				CGImageSourceRef source;
-				NSData* data = [iconImage TIFFRepresentation];
-
-				source = CGImageSourceCreateWithData((CFDataRef)data, NULL);
-				CGImageRef maskRef = CGImageSourceCreateImageAtIndex(source, 0, NULL);
-				CGContextDrawImage(myContext, CGRectMake(0, 0, [icon size].width, [icon size].height), maskRef);
-				CFRelease(source);
-				CFRelease(maskRef);
-			}
-
-			[icon unlockFocus];
-
-			return [[[IKImageWrapper alloc] initWithNSImage:icon] autorelease];
-		}
-	}
-
-	return arg1;
-}
-
-// 10.9 (List and Coverflow Views)
-- (void)IconOverlayHandlers_drawRect:(struct CGRect)arg1
-{
-	[self IconOverlayHandlers_drawRect:arg1];
+	[self IconOverlayHandlers_TDimmableIconImageView_drawRect:arg1];
 
 	NSView* supersuperview = [[(NSView*)self superview] superview];
 

--- a/mac/LiferayNativityFinder/RequestManager.m
+++ b/mac/LiferayNativityFinder/RequestManager.m
@@ -724,7 +724,6 @@ static NSInteger GOT_CALLBACK_RESPONSE = 2;
 			}
 		}
 
-
 		[callbackString release];
 
 		[socket readDataToData:[GCDAsyncSocket CRLFData] withTimeout:-1 tag:0];


### PR DESCRIPTION
10.10 requires `TColumnCell:drawIconWithFrame:` to be swizzled for Finder's column view. This is done correctly in FinderHook#install, but FinderHook#uninstall is still trying to de-swizzle the old class that was swapped out for TColumnCell. This PR fixes it to make it use TColumnCell.