### PR TITLE
Fix Mac icon view overlays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build.*.properties
 xcuserdata/
 dist
 tmp
+.settings/
 
 java/bin
 java/classes
@@ -28,3 +29,5 @@ windows/LiferayNativityShellExtensions/LiferayNativityWindowsUtil/Release
 windows/LiferayNativityShellExtensions/LiferayNativityWindowsUtil/com_liferay_nativity*
 windows/LiferayNativityShellExtensions/NativityTest/Debug
 windows/LiferayNativityShellExtensions/NativityTest/Release
+
+mac/LiferayNativityFinder/MethodNames.h

--- a/mac/LiferayNativityFinder/FinderHook.m
+++ b/mac/LiferayNativityFinder/FinderHook.m
@@ -91,7 +91,7 @@ static BOOL installed = NO;
 	// Icons
 	[self hookMethod:@selector(layerForType:) inClass:@"IKImageBrowserCell" toCallToTheNewMethod:@selector(IconOverlayHandlers_IKImageBrowserCell_layerForType:)];     // 10.7 & 10.8 & 10.9 & 10.10 (Icon View)
 
-	[self hookMethod:@selector(drawIconWithFrame:) inClass:@"TColumnCell" toCallToTheNewMethod:@selector(IconOverlayHandlers_TColumnCell_drawIconWithFrame:)];     // 10.7 & 10.8 & 10.9 & 10.10 Column View
+	[self hookMethod:@selector(drawIconWithFrame:) inClass:@"TColumnCell" toCallToTheNewMethod:@selector(IconOverlayHandlers_TColumnCell_drawIconWithFrame:)];     // 10.7 & 10.8 & 10.9 & 10.10 (Column View)
 
 	[self hookMethod:@selector(drawRect:) inClass:@"TDimmableIconImageView" toCallToTheNewMethod:@selector(IconOverlayHandlers_TDimmableIconImageView_drawRect:)];     // 10.9 & 10.10 (List and Coverflow Views)
 

--- a/mac/LiferayNativityFinder/FinderHook.m
+++ b/mac/LiferayNativityFinder/FinderHook.m
@@ -89,13 +89,11 @@ static BOOL installed = NO;
 	[RequestManager sharedInstance];
 
 	// Icons
-	[self hookMethod:@selector(drawImage:) inClass:@"IKImageBrowserCell" toCallToTheNewMethod:@selector(IconOverlayHandlers_IKImageBrowserCell_drawImage:)];     // 10.7 & 10.8 & 10.9 (Icon View arrange by name)
+	[self hookMethod:@selector(layerForType:) inClass:@"IKImageBrowserCell" toCallToTheNewMethod:@selector(IconOverlayHandlers_IKImageBrowserCell_layerForType:)];     // 10.7 & 10.8 & 10.9 & 10.10 (Icon View)
 
-	[self hookMethod:@selector(drawImage:) inClass:@"IKFinderReflectiveIconCell" toCallToTheNewMethod:@selector(IconOverlayHandlers_IKFinderReflectiveIconCell_drawImage:)];     // 10.7 & 10.8 & 10.9 (Icon View arrange by everything else)
+	[self hookMethod:@selector(drawIconWithFrame:) inClass:@"TColumnCell" toCallToTheNewMethod:@selector(IconOverlayHandlers_TColumnCell_drawIconWithFrame:)];     // 10.7 & 10.8 & 10.9 & 10.10 Column View
 
-	[self hookMethod:@selector(drawIconWithFrame:) inClass:@"TColumnCell" toCallToTheNewMethod:@selector(IconOverlayHandlers_drawIconWithFrame:)];     // 10.7 & 10.8 & 10.9 & 10.10 Column View
-
-	[self hookMethod:@selector(drawRect:) inClass:@"TDimmableIconImageView" toCallToTheNewMethod:@selector(IconOverlayHandlers_drawRect:)];     // 10.9 (List and Coverflow Views)
+	[self hookMethod:@selector(drawRect:) inClass:@"TDimmableIconImageView" toCallToTheNewMethod:@selector(IconOverlayHandlers_TDimmableIconImageView_drawRect:)];     // 10.9 & 10.10 (List and Coverflow Views)
 
 	// Context Menus
 	[self hookClassMethod:@selector(addViewSpecificStuffToMenu:browserViewController:context:) inClass:@"TContextMenu" toCallToTheNewMethod:@selector(ContextMenuHandlers_addViewSpecificStuffToMenu:browserViewController:context:)];     // 10.7 & 10.8
@@ -137,13 +135,11 @@ static BOOL installed = NO;
 	[[RequestManager sharedInstance] dealloc];
 
 	// Icons
-	[self hookMethod:@selector(IconOverlayHandlers_IKImageBrowserCell_drawImage:) inClass:@"IKImageBrowserCell" toCallToTheNewMethod:@selector(drawImage:)];     // 10.7 & 10.8 & 10.9 (Icon View arrange by name)
+	[self hookMethod:@selector(IconOverlayHandlers_IKImageBrowserCell_layerForType:) inClass:@"IKImageBrowserCell" toCallToTheNewMethod:@selector(layerForType:)];     // 10.7 & 10.8 & 10.9 & 10.10 (Icon View)
 
-	[self hookMethod:@selector(IconOverlayHandlers_IKFinderReflectiveIconCell_drawImage:) inClass:@"IKFinderReflectiveIconCell" toCallToTheNewMethod:@selector(drawImage:)];     // 10.7 & 10.8 & 10.9 (Icon View arrange by everything else)
+	[self hookMethod:@selector(IconOverlayHandlers_TColumnCell_drawIconWithFrame:) inClass:@"TColumnCell" toCallToTheNewMethod:@selector(drawIconWithFrame:)];     // 10.7 & 10.8 & 10.9 & 10.10 (Column View)
 
-	[self hookMethod:@selector(IconOverlayHandlers_drawIconWithFrame:) inClass:@"TListViewIconAndTextCell" toCallToTheNewMethod:@selector(drawIconWithFrame:)];     // 10.7 & 10.8 & 10.9 Column View
-
-	[self hookMethod:@selector(IconOverlayHandlers_drawRect:) inClass:@"TDimmableIconImageView" toCallToTheNewMethod:@selector(drawRect:)];     // 10.9 (List and Coverflow Views)
+	[self hookMethod:@selector(IconOverlayHandlers_TDimmableIconImageView_drawRect:) inClass:@"TDimmableIconImageView" toCallToTheNewMethod:@selector(drawRect:)];     // 10.9 & 10.10 (List and Coverflow Views)
 
 	// Context Menus
 	[self hookClassMethod:@selector(ContextMenuHandlers_addViewSpecificStuffToMenu:browserViewController:context:) inClass:@"TContextMenu" toCallToTheNewMethod:@selector(addViewSpecificStuffToMenu:browserViewController:context:)];     // 10.7 & 10.8

--- a/mac/LiferayNativityFinder/IconOverlayHandlers.h
+++ b/mac/LiferayNativityFinder/IconOverlayHandlers.h
@@ -51,9 +51,7 @@
 
 @interface NSObject (IconOverlayHandlers)
 
-- (void)IconOverlayHandlers_drawIconWithFrame:(struct CGRect)arg1;
-- (void)IconOverlayHandlers_drawRect:(struct CGRect)arg1;
-- (void)IconOverlayHandlers_IKFinderReflectiveIconCell_drawImage:(id)arg1;
-- (void)IconOverlayHandlers_IKImageBrowserCell_drawImage:(id)arg1;
+- (void)IconOverlayHandlers_TColumnCell_drawIconWithFrame:(struct CGRect)arg1;
+- (void)IconOverlayHandlers_TDimmableIconImageView_drawRect:(struct CGRect)arg1;
 
 @end

--- a/mac/LiferayNativityFinder/IconOverlayHandlers.m
+++ b/mac/LiferayNativityFinder/IconOverlayHandlers.m
@@ -60,13 +60,10 @@
 // 10.9 & 10.10 (List View)
 - (CALayer*) IconOverlayHandlers_IKImageBrowserCell_layerForType:(NSString *)type
 {
-	NSLog(@"LiferayNativityFinder v2: Starting layerForType with type %@", type);
-
 	CALayer *layer = [self IconOverlayHandlers_IKImageBrowserCell_layerForType:type];
 
 	if (![type isEqualToString:IKImageBrowserCellForegroundLayer])
 	{
-		NSLog(@"LiferayNativityFinder: Type not equal to IKImageBrowserCellForegroundLayer");
 		return layer;
 	}
 
@@ -82,20 +79,14 @@
 		return layer;
 	}
 
-	NSLog(@"LiferayNativityFinder: Got URL out of TIconViewCell's FINode: %@", representedItemURL);
-
 	for (NSNumber* imageIndex in [[RequestManager sharedInstance] iconIdForFile:[representedItemURL path]])
 	{
 		if ([imageIndex intValue] > 0)
 		{
 			NSImage *overlayIcon = [[IconCache sharedInstance] getIcon:[NSNumber numberWithInt:[imageIndex intValue]]];
 
-			NSLog(@"LiferayNativityFinder: Retrieved overlayIcon for iconId %@", imageIndex);
-
 			if (overlayIcon != nil)
 			{
-				NSLog(@"LiferayNativityFinder: OverlayIcon is not nil");
-
 				NSRect frame = [self frame];
 				NSRect imageFrame = [self imageFrame];
 
@@ -110,22 +101,16 @@
 				[overlayIconLayer setBounds:NSMakeRect(0, 0, imageFrame.size.width, imageFrame.size.height)];
 				[overlayIconLayer setPosition:NSMakePoint(imageFrame.origin.x - frame.origin.x, imageFrame.origin.y - frame.origin.y)];
 
-				NSLog(@"LiferayNativityFinder: Layer created %@", overlayIconLayer);
-
 				if (layer == nil)
 				{
 					layer = [CALayer layer];
 				}
 
 				[layer addSublayer:overlayIconLayer];
-
-				NSLog(@"LiferayNativityFinder: Sublayer added %@", layer);
 			}
 		}
 	}
 
-	NSLog(@"LiferayNativityFinder: Returning layer %@", layer);
-	
 	return layer;
 }
 

--- a/mac/LiferayNativityFinder/RequestManager.m
+++ b/mac/LiferayNativityFinder/RequestManager.m
@@ -361,8 +361,6 @@ static NSInteger GOT_CALLBACK_RESPONSE = 2;
 {
 	NSDictionary* iconDictionary = (NSDictionary*)cmdData;
 
-	NSLog(@"LiferayNativityFinder: execSetFileIcons %@", iconDictionary);
-
 	dispatch_async(dispatch_get_main_queue(), ^{
 		[[ContentManager sharedInstance] setIconsFor:sock.userData iconIdsByPath:iconDictionary filterByFolders:_filterFolders];
 	});
@@ -558,13 +556,9 @@ static NSInteger GOT_CALLBACK_RESPONSE = 2;
 
 	NSNumber* imageIndex = [[ContentManager sharedInstance] iconByPath:file];
 
-//	NSLog(@"LiferayNativityFinder: Icon %@ set in cache for file %@", imageIndex, file);
-
 	if ([imageIndex intValue] > 0)
 	{
-//		NSLog(@"LiferayNativityFinder: Icon %@ found in cache for file %@", imageIndex, file);
 		[iconIds addObject:imageIndex];
-		return [iconIds autorelease];
 	}
 
 	// Why not just call [_connectedListenSocketsWithIconCallbacks count] directly?

--- a/mac/LiferayNativityFinder/RequestManager.m
+++ b/mac/LiferayNativityFinder/RequestManager.m
@@ -361,6 +361,8 @@ static NSInteger GOT_CALLBACK_RESPONSE = 2;
 {
 	NSDictionary* iconDictionary = (NSDictionary*)cmdData;
 
+	NSLog(@"LiferayNativityFinder: execSetFileIcons %@", iconDictionary);
+
 	dispatch_async(dispatch_get_main_queue(), ^{
 		[[ContentManager sharedInstance] setIconsFor:sock.userData iconIdsByPath:iconDictionary filterByFolders:_filterFolders];
 	});
@@ -556,9 +558,13 @@ static NSInteger GOT_CALLBACK_RESPONSE = 2;
 
 	NSNumber* imageIndex = [[ContentManager sharedInstance] iconByPath:file];
 
+//	NSLog(@"LiferayNativityFinder: Icon %@ set in cache for file %@", imageIndex, file);
+
 	if ([imageIndex intValue] > 0)
 	{
+//		NSLog(@"LiferayNativityFinder: Icon %@ found in cache for file %@", imageIndex, file);
 		[iconIds addObject:imageIndex];
+		return [iconIds autorelease];
 	}
 
 	// Why not just call [_connectedListenSocketsWithIconCallbacks count] directly?
@@ -723,7 +729,6 @@ static NSInteger GOT_CALLBACK_RESPONSE = 2;
 				[_callbackLock unlockWithCondition:WAITING_FOR_CALLBACK_RESPONSE];
 			}
 		}
-
 
 		[callbackString release];
 


### PR DESCRIPTION
Different way of displaying icon overlays in Mac Finder's icon view. This doesn't involve expensive TIFF conversion or redrawing the icon in a different graphics window, which is must faster. The old way caused Finder's CPU to spike to 100+% and was incredibly slow to navigate around in icon view mode.