### PR TITLE
Fixed bug in TestDriver

### DIFF
--- a/java/test/com/liferay/nativity/test/TestDriver.java
+++ b/java/test/com/liferay/nativity/test/TestDriver.java
@@ -167,8 +167,8 @@ public class TestDriver {
 	}
 
 	private static void _registerFileIcon(FileIconControl fileIconControl) {
-		_fileIconId = fileIconControl.registerIcon(_fileIconPath);
-
+		fileIconControl.registerIconWithId(_fileIconPath, "", Integer.toString(_fileIconId));
+		
 		try {
 			Thread.sleep(_waitTime);
 		}


### PR DESCRIPTION
Hi,

we discovered a bug in the TestDriver class causing errors in unit tests when registering file icons.
This commit should fix it.

Regards,
Christian