### PR TITLE
Fixed Visual Studio project settings

### DIFF
--- a/windows/LiferayNativityShellExtensions/LiferayNativityContextMenus/LiferayNativityContextMenus.vcxproj
+++ b/windows/LiferayNativityShellExtensions/LiferayNativityContextMenus/LiferayNativityContextMenus.vcxproj
@@ -33,7 +33,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>Windows7.1SDK</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/windows/LiferayNativityShellExtensions/LiferayNativityOverlays/LiferayNativityOverlays.vcxproj
+++ b/windows/LiferayNativityShellExtensions/LiferayNativityOverlays/LiferayNativityOverlays.vcxproj
@@ -33,7 +33,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>Windows7.1SDK</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/windows/LiferayNativityShellExtensions/LiferayNativityShellExtensions.sln
+++ b/windows/LiferayNativityShellExtensions/LiferayNativityShellExtensions.sln
@@ -1,8 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
-MinimumVisualStudioVersion = 10.0.40219.1
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "LiferayNativityContextMenus", "LiferayNativityContextMenus\LiferayNativityContextMenus.vcxproj", "{E9BC5587-A688-4C36-8B15-DAFBAAAADCAE}"
 	ProjectSection(ProjectDependencies) = postProject
 		{E4F63E19-808D-4234-8DF0-69C5F47C9CD3} = {E4F63E19-808D-4234-8DF0-69C5F47C9CD3}
@@ -13,9 +11,6 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "LiferayNativityUtil", "LiferayNativityUtil\LiferayNativityUtil.vcxproj", "{E4F63E19-808D-4234-8DF0-69C5F47C9CD3}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "LiferayNativityWindowsUtil", "LiferayNativityWindowsUtil\LiferayNativityWindowsUtil.vcxproj", "{04E95851-453A-4215-A830-CBCB3A675647}"
-	ProjectSection(ProjectDependencies) = postProject
-		{E4F63E19-808D-4234-8DF0-69C5F47C9CD3} = {E4F63E19-808D-4234-8DF0-69C5F47C9CD3}
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/windows/LiferayNativityShellExtensions/LiferayNativityUtil/LiferayNativityUtil.vcxproj
+++ b/windows/LiferayNativityShellExtensions/LiferayNativityUtil/LiferayNativityUtil.vcxproj
@@ -32,7 +32,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>Windows7.1SDK</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/windows/LiferayNativityShellExtensions/LiferayNativityWindowsUtil/LiferayNativityWindowsUtil.vcxproj
+++ b/windows/LiferayNativityShellExtensions/LiferayNativityWindowsUtil/LiferayNativityWindowsUtil.vcxproj
@@ -32,7 +32,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>Windows7.1SDK</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -46,7 +46,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>Windows7.1SDK</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
Hi,

we tried to compile the current version of liferay-nativity for Windows using the Ant script but had some problems with the settings of the PlatformToolset. It seems that the Visual Studio project files have mixed settings. Sometimes the PlatformToolset is set to v120, sometimes it is set to Windows7.1SDK. I guess this is not intended. We reset everything back to Visual Studio 2010 and Windows7.1SDK and everything works fine now. Maybe you want to add our fix.

Kind Regards,
Christian