### PR TITLE
Fixed reading of registry entries

### DIFF
--- a/windows/LiferayNativityShellExtensions/LiferayNativityUtil/RegistryUtil.cpp
+++ b/windows/LiferayNativityShellExtensions/LiferayNativityUtil/RegistryUtil.cpp
@@ -48,7 +48,7 @@ bool RegistryUtil::ReadRegistry(const wchar_t* key, const wchar_t* name, wstring
 	wchar_t value[SIZE];
 	DWORD value_length = SIZE;
 
-	hResult = RegQueryValueEx(rootKey, (LPCWSTR)name, NULL, NULL, (LPBYTE)value, &value_length);
+	hResult = HRESULT_FROM_WIN32(RegQueryValueEx(rootKey, (LPCWSTR)name, NULL, NULL, (LPBYTE)value, &value_length));
 
 	if (!SUCCEEDED(hResult))
 	{
@@ -57,9 +57,9 @@ bool RegistryUtil::ReadRegistry(const wchar_t* key, const wchar_t* name, wstring
 
 	result->append(value);
 
-	HRESULT hResult2 = RegCloseKey(rootKey);
+	hResult = HRESULT_FROM_WIN32(RegCloseKey(rootKey));
 
-	if (!SUCCEEDED(hResult2))
+	if (!SUCCEEDED(hResult))
 	{
 		return false;
 	}


### PR DESCRIPTION
Hi again,

we discovered a bug in the LiferayNativityUtil.dll.
The results of RegQueryValueEx and RegCloseKey are not correctly evaluated, which causes continuous crashing and restarting of the Windows Explorer, if a queried registry key cannot be found. This change should fix it.

Regards,
Christian