### PR TITLE
Fixed multiple sub menus in Finder context menu

### DIFF
--- a/mac/FinderSync/LiferayFinderSync/RequestManager.m
+++ b/mac/FinderSync/LiferayFinderSync/RequestManager.m
@@ -181,7 +181,7 @@ static RequestManager* sharedInstance = nil;
 
 		[_menuUuidDictionary setValue:menuUuidDictionary forKey:uuid];
 
-		SEL actionSelector = sel_registerName([[@"__CONTEXT_MENU_ACTION_" stringByAppendingString:[@(index)stringValue]] UTF8String]);
+		SEL actionSelector = sel_registerName([[@"__CONTEXT_MENU_ACTION_" stringByAppendingString:[[[@(index)stringValue] stringByAppendingString:@"_"] stringByAppendingString:title]] UTF8String]);
 
 		IMP methodIMP = imp_implementationWithBlock(^(id _self) {
 			[[RequestManager sharedInstance] sendMenuItemClicked:uuid];


### PR DESCRIPTION
Hi,

we discovered a problem with context menus on OS X.
If there are multiple sub menus defined in the context menu, only the functions of the last sub menu are called. The reason is that the functions are mapped to the index of the respective menu item. Every sub menu starts counting the index again from 0, so a second sub menu overwrites the function defined by the first sub menu.
This fix adds the title of the menu item to the mapping, so no more collisions should occur.

Regards,
Christian